### PR TITLE
task: Swift URL macro support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -8,6 +8,15 @@
         "revision" : "d7b896fa9ca8b47fa7bcde6b43ef9b70bf8c1f56",
         "version" : "1.8.1"
       }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
+        "version" : "509.1.1"
+      }
     }
   ],
   "version" : 2

--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,13 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
+import CompilerPluginSupport
 
 let package = Package(
     name: "GoodExtensions",
     platforms: [
+        .macOS(.v12),
         .iOS(.v13)
     ],
     products: [
@@ -22,10 +24,15 @@ let package = Package(
             name: "GoodCombineExtensions",
             targets: ["GoodCombineExtensions"]
         ),
+        .library(
+            name: "GoodMacros",
+            targets: ["GoodMacros"]
+        )
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/CombineCommunity/CombineExt.git", from: "1.0.0")
+        .package(url: "https://github.com/CombineCommunity/CombineExt.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.2")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -49,6 +56,19 @@ let package = Package(
             name: "GoodStructs",
             dependencies: [],
             path: "./Sources/GoodStructs"
+        ),
+        .target(
+            name: "GoodMacros",
+            dependencies: ["MacroCollection"],
+            path: "./Sources/GoodMacros"
+        ),
+        .macro(
+            name: "MacroCollection",
+            dependencies: [
+                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+                .product(name: "SwiftCompilerPlugin", package: "swift-syntax")
+            ],
+            path: "./Sources/MacroCollection"
         ),
         .testTarget(
             name: "GoodExtensionsTests",

--- a/Sources/GoodMacros/GoodMacros.swift
+++ b/Sources/GoodMacros/GoodMacros.swift
@@ -1,0 +1,11 @@
+//
+//  GoodMacros.swift
+//  GoodExtensions-iOS
+//
+//  Created by Filip Šašala on 04/04/2024.
+//
+
+import Foundation
+
+@freestanding(expression)
+public macro URL(_ string: String) -> URL = #externalMacro(module: "MacroCollection", type: "URLMacro")

--- a/Sources/MacroCollection/MacroCollection.swift
+++ b/Sources/MacroCollection/MacroCollection.swift
@@ -1,0 +1,18 @@
+//
+//  MacroCollection.swift
+//  GoodExtensions-iOS
+//
+//  Created by Filip Šašala on 04/04/2024.
+//
+
+import Foundation
+import SwiftCompilerPlugin
+import SwiftSyntaxMacros
+
+@main struct Plugins: CompilerPlugin {
+
+    let providingMacros: [Macro.Type] = [
+        URLMacro.self
+    ]
+
+}

--- a/Sources/MacroCollection/URLMacro.swift
+++ b/Sources/MacroCollection/URLMacro.swift
@@ -1,0 +1,49 @@
+//
+//  URLMacro.swift
+//  GoodExtensions-iOS
+//
+//  Created by Filip Šašala on 04/04/2024.
+//
+
+import Foundation
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public struct URLMacro: ExpressionMacro {
+
+    public static func expansion(
+        of node: some FreestandingMacroExpansionSyntax,
+        in context: some MacroExpansionContext
+    ) throws -> ExprSyntax {
+        guard let argument = node.argumentList.first?.expression,
+              let segments = argument.as(StringLiteralExprSyntax.self)?.segments,
+              segments.count == 1,
+              case .stringSegment(let literalSegment)? = segments.first
+        else {
+            throw URLMacroError.requiresStaticStringLiteral
+        }
+        guard URL(string: literalSegment.content.text) != nil else {
+            throw URLMacroError.malformedURL(urlString: "\(argument)")
+        }
+
+        return "URL(string: \(argument))!"
+    }
+
+}
+
+enum URLMacroError: Error, CustomStringConvertible {
+
+    case requiresStaticStringLiteral
+    case malformedURL(urlString: String)
+
+    var description: String {
+        switch self {
+        case .requiresStaticStringLiteral:
+            "#URL macro requires a static string literal"
+
+        case .malformedURL(let urlString):
+            "URL is malformed: \(urlString)"
+        }
+    }
+
+}


### PR DESCRIPTION
Adds `#URL` macro. URL is checked at compile time and aborts build if malformed/missing/invalid. 

Example:
```swift
let exampleUrl = URL(string: "https://example.com/")
let exampleUrlMacro = #URL("https://example.com/")

// Type of exampleUrl: Optional<URL>
// Type of exampleUrlMacro: URL
```

Requirements: URL must be a string literal and cannot be interpolated at runtime.

This PR also serves as a foundation for development/inclusion of future macros.