### PR TITLE
feat: Version struct

### DIFF
--- a/Sources/GoodStructs/Version.swift
+++ b/Sources/GoodStructs/Version.swift
@@ -1,0 +1,345 @@
+//
+//  Version.swift
+//  GoodStructs
+//
+//  Created by Filip Šašala on 28/05/2024.
+//
+
+import Foundation
+import RegexBuilder
+
+// MARK: - Version
+
+@available(iOS 16.0, *)
+@available(macOS 13.0, *)
+public struct Version {
+
+    public var major: UInt
+    public var minor: UInt
+    public var patch: UInt
+    public var stage: ReleaseStage
+    public var build: UInt
+    public var suffix: String?
+
+    public init(
+        major: UInt = 1,
+        minor: UInt = 0,
+        patch: UInt = 0,
+        prerelease: ReleaseStage = .release,
+        build: UInt = 0,
+        suffix: String? = nil
+    ) {
+        self.major = major
+        self.minor = minor
+        self.patch = patch
+        self.stage = prerelease
+        self.build = build
+        self.suffix = suffix
+    }
+
+    public init(string: String) throws {
+        let majorVersion = TryCapture {
+            OneOrMore(.digit)
+        } transform: { major in
+            UInt(major)
+        }
+        let minorVersion = Optionally {
+            TryCapture {
+                OneOrMore(.digit)
+            } transform: { minor in
+                UInt(minor)
+            }
+        }
+        let patchVersion = Optionally {
+            TryCapture {
+                OneOrMore(.digit)
+            } transform: { patch in
+                UInt(patch)
+            }
+        }
+        let releaseStage = Optionally {
+            TryCapture {
+                OneOrMore(.word)
+            } transform: { stage in
+                ReleaseStage(rawValue: String(stage))
+            }
+        }
+        let buildNumber = Optionally {
+            TryCapture {
+                OneOrMore(.digit)
+            } transform: { build in
+                UInt(build)
+            }
+        }
+        let suffix = Optionally {
+            TryCapture {
+                OneOrMore(.any)
+            } transform: { suffix in
+                String(suffix)
+            }
+        }
+
+        let regex = Regex {
+            majorVersion
+            Optionally(".")
+            minorVersion
+            Optionally(".")
+            patchVersion
+            // Stage
+            Optionally("-")
+            releaseStage
+            // Bulid number
+            Optionally(".")
+            buildNumber
+            // Suffix
+            Optionally("+")
+            suffix
+        }
+
+        if let result = string.firstMatch(of: regex)?.output {
+            let major = result.1
+            let minor = result.2 ?? 0
+            let patch = result.3 ?? 0
+            let stage = result.4 ?? .release
+            let build = result.5 ?? 0
+            let suffix = result.6
+
+            self.major = major
+            self.minor = minor
+            self.patch = patch
+            self.stage = stage
+            self.build = build
+            self.suffix = suffix
+        } else {
+            throw VersionError.invalidVersion(string)
+        }
+    }
+
+    public init(branchName string: String) throws {
+        let majorVersion = TryCapture {
+            OneOrMore(.digit)
+        } transform: { major in
+            UInt(major)
+        }
+        let minorVersion = Optionally {
+            TryCapture {
+                OneOrMore(.digit)
+            } transform: { minor in
+                UInt(minor)
+            }
+        }
+        let patchVersion = Optionally {
+            TryCapture {
+                OneOrMore(.digit)
+            } transform: { patch in
+                UInt(patch)
+            }
+        }
+        let releaseStage = TryCapture {
+            OneOrMore(.any)
+        } transform: { stage in
+            ReleaseStage(rawValue: String(stage))
+        }
+        let suffix = Optionally {
+            TryCapture {
+                OneOrMore(.any)
+            } transform: { suffix in
+                String(suffix)
+            }
+        }
+
+        let regex = Regex {
+            "release/"
+            // Release stage
+            releaseStage
+            "_"
+            // Release version
+            majorVersion
+            Optionally(".")
+            minorVersion
+            Optionally(".")
+            patchVersion
+            // Suffix
+            Optionally("+")
+            suffix
+        }
+
+        if let result = string.firstMatch(of: regex)?.output {
+            self.major = result.2
+            self.minor = result.3 ?? 0
+            self.patch = result.4 ?? 0
+            self.stage = result.1
+            self.build = 0
+            self.suffix = result.5
+        } else {
+            throw VersionError.invalidVersion(string)
+        }
+    }
+
+}
+
+// MARK: - CustonStringConvertible
+
+@available(iOS 16.0, *)
+@available(macOS 13.0, *)
+extension Version: CustomStringConvertible, CustomDebugStringConvertible {
+
+    public var description: String {
+        let usesBuildStages = !(stage == .release && build == 0)
+
+        if usesBuildStages {
+            return debugDescription
+        } else {
+            return version
+        }
+    }
+
+    public var debugDescription: String {
+        if let suffix, !suffix.isEmpty {
+            return "\(major).\(minor).\(patch)-\(stage).\(build)+\(suffix)"
+        } else {
+            return "\(major).\(minor).\(patch)-\(stage).\(build)"
+        }
+    }
+
+    public var version: String {
+        "\(major).\(minor).\(patch)"
+    }
+
+}
+
+// MARK: - Equatable, Comparable
+
+@available(iOS 16.0, *)
+@available(macOS 13.0, *)
+extension Version: Equatable, Comparable {
+
+    public static func == (lhs: Version, rhs: Version) -> Bool {
+        lhs.major == rhs.major
+        && lhs.minor == rhs.minor
+        && lhs.patch == rhs.patch
+        && lhs.stage == rhs.stage
+        && lhs.build == rhs.build
+    }
+
+    public static func < (lhs: Version, rhs: Version) -> Bool {
+        if lhs.major != rhs.major {
+            return lhs.major < rhs.major
+        } else if lhs.minor != rhs.minor {
+            return lhs.minor < rhs.minor
+        } else if lhs.patch != rhs.patch {
+            return lhs.patch < rhs.patch
+        } else if lhs.stage.comparableValue != rhs.stage.comparableValue {
+            return lhs.stage.comparableValue < rhs.stage.comparableValue
+        } else if lhs.build != rhs.build {
+            return lhs.build < rhs.build
+        } else {
+            return (lhs.suffix ?? "") < (rhs.suffix ?? "")
+        }
+    }
+
+}
+
+// MARK: - Codable
+
+@available(iOS 16.0, *)
+@available(macOS 13.0, *)
+extension Version: Codable {
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let versionString = try container.decode(String.self)
+
+        try self.init(string: versionString)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.description)
+    }
+
+}
+
+// MARK: - Parser, Formatter
+
+@available(iOS 16.0, *)
+@available(macOS 13.0, *)
+public struct VersionParseStrategy: ParseStrategy {
+
+    public typealias ParseInput = String
+    public typealias ParseOutput = Version
+
+    public func parse(_ value: String) throws -> Version {
+        try Version(string: value)
+    }
+
+}
+
+@available(iOS 16.0, *)
+@available(macOS 13.0, *)
+struct VersionFormatStyle: ParseableFormatStyle {
+
+    public typealias Strategy = VersionParseStrategy
+    public typealias FormatInput = Version
+    public typealias FormatOutput = String
+
+    public var parseStrategy: Strategy {
+        Strategy()
+    }
+
+    public func format(_ value: Version) -> String {
+        value.version
+    }
+
+}
+
+// MARK: - Stage
+
+@available(iOS 16.0, *)
+@available(macOS 13.0, *)
+public enum ReleaseStage: String {
+
+    case alpha
+    case beta
+    case release
+
+    public init?(rawValue: String) {
+        switch rawValue {
+        case "alpha", "bitrise":
+            self = .alpha
+
+        case "beta", "testflight_dev", "testflight":
+            self = .beta
+
+        case "rc", "release", "testflight_release", "appstore":
+            self = .release
+
+        default:
+            return nil
+        }
+    }
+
+    public var comparableValue: UInt {
+        switch self {
+        case .alpha:
+            return 1
+
+        case .beta:
+            return 2
+
+        case .release:
+            return 3
+        }
+    }
+
+}
+
+// MARK: - Errors
+
+@available(iOS 16.0, *)
+@available(macOS 13.0, *)
+public enum VersionError: Error {
+
+    case invalidVersion(String)
+
+}

--- a/Tests/GoodStructsTests/VersionTests.swift
+++ b/Tests/GoodStructsTests/VersionTests.swift
@@ -1,0 +1,385 @@
+//
+//  VersionTests.swift
+//  GoodStructs
+//
+//  Created by Filip Šašala on 14/02/2024.
+//
+
+import XCTest
+import GoodStructs
+import GoodMacros
+
+@available(iOS 16.0, *)
+@available(macOS 13.0, *)
+final class VersionTests: XCTestCase {
+
+    struct VersionContainer: Codable {
+        let version: Version
+    }
+
+    // MARK: - Initialization Tests
+
+    func testVersionFromStringNoStage() throws {
+        let versionString = "1.0.0"
+        let tryMakeVersion = { try Version(string: versionString) }
+
+        XCTAssertNoThrow(tryMakeVersion)
+
+        let version = try tryMakeVersion()
+        XCTAssertEqual(version.major, 1)
+        XCTAssertEqual(version.minor, 0)
+        XCTAssertEqual(version.patch, 0)
+        XCTAssertEqual(version.stage, .release)
+        XCTAssertEqual(version.build, 0)
+        XCTAssertEqual(version.suffix, nil)
+    }
+
+    func testVersionFromStringOnlyMajor() throws {
+        let versionString = "1-alpha"
+        let version = try Version(string: versionString)
+
+        XCTAssertEqual(version.major, 1)
+        XCTAssertEqual(version.minor, 0)
+        XCTAssertEqual(version.patch, 0)
+        XCTAssertEqual(version.stage, .alpha)
+        XCTAssertEqual(version.build, 0)
+        XCTAssertEqual(version.suffix, nil)
+    }
+
+    func testVersionFromStringOnlyMajorAndBuild() throws {
+        let versionString = "1-beta.2"
+        let version = try Version(string: versionString)
+
+        XCTAssertEqual(version.major, 1)
+        XCTAssertEqual(version.minor, 0)
+        XCTAssertEqual(version.patch, 0)
+        XCTAssertEqual(version.stage, .beta)
+        XCTAssertEqual(version.build, 2)
+        XCTAssertEqual(version.suffix, nil)
+    }
+
+    func testVersionFromStringOnlyMajorMinor() throws {
+        let versionString = "1.2-alpha"
+        let version = try Version(string: versionString)
+
+        XCTAssertEqual(version.major, 1)
+        XCTAssertEqual(version.minor, 2)
+        XCTAssertEqual(version.patch, 0)
+        XCTAssertEqual(version.stage, .alpha)
+        XCTAssertEqual(version.build, 0)
+        XCTAssertEqual(version.suffix, nil)
+    }
+
+    func testVersionFromStringOnlyMajorMinorPatch() throws {
+        let versionString = "1.2.31-alpha"
+        let version = try Version(string: versionString)
+
+        XCTAssertEqual(version.major, 1)
+        XCTAssertEqual(version.minor, 2)
+        XCTAssertEqual(version.patch, 31)
+        XCTAssertEqual(version.stage, .alpha)
+        XCTAssertEqual(version.build, 0)
+        XCTAssertEqual(version.suffix, nil)
+    }
+
+    func testVersionFromStringOnlyMajorAndSuffix() throws {
+        let versionString = "1-alpha+ew"
+        let version = try Version(string: versionString)
+
+        XCTAssertEqual(version.major, 1)
+        XCTAssertEqual(version.minor, 0)
+        XCTAssertEqual(version.patch, 0)
+        XCTAssertEqual(version.stage, .alpha)
+        XCTAssertEqual(version.build, 0)
+        XCTAssertEqual(version.suffix, "ew")
+    }
+
+    func testVersionFromStringOnlyMajorMinorAndSuffix() throws {
+        let versionString = "1.22-alpha+ew"
+        let version = try Version(string: versionString)
+
+        XCTAssertEqual(version.major, 1)
+        XCTAssertEqual(version.minor, 22)
+        XCTAssertEqual(version.patch, 0)
+        XCTAssertEqual(version.stage, .alpha)
+        XCTAssertEqual(version.build, 0)
+        XCTAssertEqual(version.suffix, "ew")
+    }
+
+    func testVersionFromStringAlpha() throws {
+        let versionString = "1.0.0-alpha.1"
+        let version = try Version(string: versionString)
+
+        XCTAssertEqual(version.major, 1)
+        XCTAssertEqual(version.minor, 0)
+        XCTAssertEqual(version.patch, 0)
+        XCTAssertEqual(version.stage, .alpha)
+        XCTAssertEqual(version.build, 1)
+        XCTAssertEqual(version.suffix, nil)
+    }
+
+    func testVersionFromStringBeta() throws {
+        let versionString = "2.15.4-beta.8"
+        let version = try Version(string: versionString)
+
+        XCTAssertEqual(version.major, 2)
+        XCTAssertEqual(version.minor, 15)
+        XCTAssertEqual(version.patch, 4)
+        XCTAssertEqual(version.stage, .beta)
+        XCTAssertEqual(version.build, 8)
+        XCTAssertEqual(version.suffix, nil)
+    }
+
+    func testVersionFromStringReleaseCandidate() throws {
+        let versionString = "3.5.0-rc.2"
+        let version = try Version(string: versionString)
+
+        XCTAssertEqual(version.major, 3)
+        XCTAssertEqual(version.minor, 5)
+        XCTAssertEqual(version.patch, 0)
+        XCTAssertEqual(version.stage, .release)
+        XCTAssertEqual(version.build, 2)
+        XCTAssertEqual(version.suffix, nil)
+    }
+
+    func testVersionFromStringAlphaWithSuffix() throws {
+        let versionString = "1.0.0-alpha.1+ew"
+        let version = try Version(string: versionString)
+
+        XCTAssertEqual(version.major, 1)
+        XCTAssertEqual(version.minor, 0)
+        XCTAssertEqual(version.patch, 0)
+        XCTAssertEqual(version.stage, .alpha)
+        XCTAssertEqual(version.build, 1)
+        XCTAssertEqual(version.suffix, "ew")
+    }
+
+    func testVersionFromStringAlphaWithSuffix2() throws {
+        let versionString = "1.0.0-alpha.1+ew+2"
+        let version = try Version(string: versionString)
+
+        XCTAssertEqual(version.major, 1)
+        XCTAssertEqual(version.minor, 0)
+        XCTAssertEqual(version.patch, 0)
+        XCTAssertEqual(version.stage, .alpha)
+        XCTAssertEqual(version.build, 1)
+        XCTAssertEqual(version.suffix, "ew+2")
+    }
+
+    // MARK: - Branch name tests
+
+    func testVersionFromBranchBitrise() throws {
+        let branchName = "release/bitrise_1.0.0"
+        let version = try Version(branchName: branchName)
+
+        XCTAssertEqual(version.major, 1)
+        XCTAssertEqual(version.minor, 0)
+        XCTAssertEqual(version.patch, 0)
+        XCTAssertEqual(version.stage, .alpha)
+        XCTAssertEqual(version.build, 0)
+        XCTAssertEqual(version.suffix, nil)
+    }
+
+    func testVersionFromBranchBitriseOnlyMajor() throws {
+        let branchName = "release/bitrise_2"
+        let version = try Version(branchName: branchName)
+
+        XCTAssertEqual(version.major, 2)
+        XCTAssertEqual(version.minor, 0)
+        XCTAssertEqual(version.patch, 0)
+        XCTAssertEqual(version.stage, .alpha)
+        XCTAssertEqual(version.build, 0)
+        XCTAssertEqual(version.suffix, nil)
+    }
+
+    func testVersionFromBranchBitriseOnlyMajorWithSuffix() throws {
+        let branchName = "release/bitrise_2+ew"
+        let version = try Version(branchName: branchName)
+
+        XCTAssertEqual(version.major, 2)
+        XCTAssertEqual(version.minor, 0)
+        XCTAssertEqual(version.patch, 0)
+        XCTAssertEqual(version.stage, .alpha)
+        XCTAssertEqual(version.build, 0)
+        XCTAssertEqual(version.suffix, "ew")
+    }
+
+    func testVersionFromBranchTestflightOnlyMajorMinor() throws {
+        let branchName = "release/testflight_dev_2.152"
+        let version = try Version(branchName: branchName)
+
+        XCTAssertEqual(version.major, 2)
+        XCTAssertEqual(version.minor, 152)
+        XCTAssertEqual(version.patch, 0)
+        XCTAssertEqual(version.stage, .beta)
+        XCTAssertEqual(version.build, 0)
+        XCTAssertEqual(version.suffix, nil)
+    }
+
+    func testVersionFromBranchTestflight() throws {
+        let branchName = "release/testflight_dev_2.15.4"
+        let version = try Version(branchName: branchName)
+
+        XCTAssertEqual(version.major, 2)
+        XCTAssertEqual(version.minor, 15)
+        XCTAssertEqual(version.patch, 4)
+        XCTAssertEqual(version.stage, .beta)
+        XCTAssertEqual(version.build, 0)
+        XCTAssertEqual(version.suffix, nil)
+    }
+
+    func testVersionFromBranchTestflightRelease() throws {
+        let branchName = "release/testflight_release_3.5.0"
+        let version = try Version(branchName: branchName)
+
+        XCTAssertEqual(version.major, 3)
+        XCTAssertEqual(version.minor, 5)
+        XCTAssertEqual(version.patch, 0)
+        XCTAssertEqual(version.stage, .release)
+        XCTAssertEqual(version.build, 0)
+        XCTAssertEqual(version.suffix, nil)
+    }
+
+    func testVersionFromBranchBitriseWithSuffix() throws {
+        let branchName = "release/bitrise_1.0.0+ew"
+        let version = try Version(branchName: branchName)
+
+        XCTAssertEqual(version.major, 1)
+        XCTAssertEqual(version.minor, 0)
+        XCTAssertEqual(version.patch, 0)
+        XCTAssertEqual(version.stage, .alpha)
+        XCTAssertEqual(version.build, 0)
+        XCTAssertEqual(version.suffix, "ew")
+    }
+
+    func testVersionFromBranchBitriseWithSuffix2() throws {
+        let branchName = "release/bitrise_1.0.0+ew+2"
+        let version = try Version(branchName: branchName)
+
+        XCTAssertEqual(version.major, 1)
+        XCTAssertEqual(version.minor, 0)
+        XCTAssertEqual(version.patch, 0)
+        XCTAssertEqual(version.stage, .alpha)
+        XCTAssertEqual(version.build, 0)
+        XCTAssertEqual(version.suffix, "ew+2")
+    }
+
+    func testVersionFromBranchTestflightWithSuffix() throws {
+        let branchName = "release/testflight_dev_2.15.4+ew"
+        let version = try Version(branchName: branchName)
+
+        XCTAssertEqual(version.major, 2)
+        XCTAssertEqual(version.minor, 15)
+        XCTAssertEqual(version.patch, 4)
+        XCTAssertEqual(version.stage, .beta)
+        XCTAssertEqual(version.build, 0)
+        XCTAssertEqual(version.suffix, "ew")
+    }
+
+    func testVersionFromBranchTestflightReleaseWithSuffix() throws {
+        let branchName = "release/testflight_release_3.5.0+ew"
+        let version = try Version(branchName: branchName)
+
+        XCTAssertEqual(version.major, 3)
+        XCTAssertEqual(version.minor, 5)
+        XCTAssertEqual(version.patch, 0)
+        XCTAssertEqual(version.stage, .release)
+        XCTAssertEqual(version.build, 0)
+        XCTAssertEqual(version.suffix, "ew")
+    }
+
+    // MARK: - Description Tests
+
+    func testVersionToString() throws {
+        let versionString = "1.0.0-alpha.1"
+        let version = try Version(string: versionString)
+
+        XCTAssertEqual(version.description, versionString)
+    }
+
+    func testVersionToStringWithSuffix() throws {
+        let versionString = "1.0.0-alpha.1+ew"
+        let version = try Version(string: versionString)
+
+        XCTAssertEqual(version.description, versionString)
+    }
+
+    func testVersionToStringWithSuffixEmpty() throws {
+        let versionString = "1.0.0-alpha.1+"
+        let version = try Version(string: versionString)
+
+        XCTAssertEqual(version.description, "1.0.0-alpha.1")
+    }
+
+    func testVersionToStringPlain() throws {
+        let versionString = "2.3.5"
+        let version = try Version(string: versionString)
+
+        XCTAssertEqual(version.description, "2.3.5")
+        XCTAssertEqual(version.debugDescription, "2.3.5-release.0")
+    }
+
+    // MARK: - Ordering tests
+
+    func testVersionOrdering() throws {
+        let version1 = Version()                                                               // 1.0.0
+        let version11 = Version(major: 1, minor: 1)                                            // 1.1.0
+        let version111 = Version(major: 1, minor: 1, patch: 1)                                 // 1.1.1
+        let version2a0 = Version(major: 2, prerelease: .alpha)                                 // 2.0.0-alpha.0
+        let version2b1 = Version(major: 2, prerelease: .beta, build: 1)                        // 2.0.0-beta.1
+        let version2b1a = Version(major: 2, prerelease: .beta, build: 1, suffix: "a")          // 2.0.0-beta.1+a
+        let version2b1b = Version(major: 2, prerelease: .beta, build: 1, suffix: "b")          // 2.0.0-beta.1+b
+        let version2 = Version(major: 2)                                                       // 2.0.0
+        let version21 = Version(major: 2, minor: 1)                                            // 2.1.0
+        let version211a3 = Version(major: 2, minor: 1, patch: 1, prerelease: .alpha, build: 3) // 2.1.1-alpha.3
+        let version211 = Version(major: 2, minor: 1, patch: 1)                                 // 2.1.1
+
+        XCTAssertLessThan(version1, version11)
+        XCTAssertLessThan(version11, version111)
+        XCTAssertLessThan(version111, version2)
+        XCTAssertLessThan(version2, version21)
+        XCTAssertLessThan(version21, version211)
+
+        XCTAssertGreaterThan(version211a3, version21)
+        XCTAssertLessThan(version211a3, version211)
+
+        XCTAssertLessThan(version2b1a, version2b1b)
+        XCTAssertLessThan(version2b1a, version2)
+        XCTAssertGreaterThan(version2b1b, version2b1a)
+        XCTAssertGreaterThan(version2b1a, version2a0)
+
+        XCTAssertLessThan(version2b1, version2b1a)
+
+        XCTAssertEqual(version211a3, version211a3)
+    }
+
+    // MARK: - Codable Tests
+
+    func testVersionDecodable() throws {
+        let jsonString = "{\"version\":\"1\"}"
+        let jsonData = jsonString.data(using: .utf8)!
+
+        let originalDecodeVersion = Version(major: 1, minor: 0, patch: 0)
+        let decodedContainer = try JSONDecoder().decode(VersionContainer.self, from: jsonData)
+
+        XCTAssertEqual(originalDecodeVersion, decodedContainer.version)
+    }
+
+    func testVersionEncodable() throws {
+        let originalEncodeVersion = Version(
+            major: 2,
+            minor: 3,
+            patch: 6,
+            prerelease: .beta,
+            build: 4,
+            suffix: "test"
+        )
+        let originalEncodeVersionContainer = VersionContainer(version: originalEncodeVersion)
+        let originalEncodeVersionContainerString = "{\"version\":\"2.3.6-beta.4+test\"}"
+        let encodedData = try JSONEncoder().encode(originalEncodeVersionContainer)
+        let encodedString = String(data: encodedData, encoding: .utf8)!
+
+        XCTAssertEqual(encodedString, originalEncodeVersionContainerString)
+    }
+
+}


### PR DESCRIPTION
Presuvam `Version` struct sem aj s testami, kedze sa pouziva na viacerych miestach, aby sa zabranilo kopirovaniu a desynchronizacii kodu.